### PR TITLE
Fix tasks for the VSCode integration

### DIFF
--- a/ModdingTools/Headless/CommandLineOptions.cs
+++ b/ModdingTools/Headless/CommandLineOptions.cs
@@ -20,6 +20,9 @@ namespace ModdingTools.Headless
         [Option(Group = "task", HelpText = "Launch editor")]
         public bool Editor { get; set; }
 
+        [Option(Group = "task", HelpText = "Kill editor")]
+        public bool KillEditor { get; set; }
+
         [Option("testmap", HelpText = "Test map", Group = "task")]
         public string TestMap { get; set; }
 

--- a/ModdingTools/Headless/ProgramHeadless.cs
+++ b/ModdingTools/Headless/ProgramHeadless.cs
@@ -121,6 +121,12 @@ namespace ModdingTools.Headless
             }
             else
             {
+                if(o.KillEditor)
+                {
+                    Utils.KillEditor();
+                    return 0;
+                }
+
                 if (o.TestMapAll != null)
                 {
                     RunSteamAPI(true);

--- a/ModdingTools/Headless/ProgramHeadless.cs
+++ b/ModdingTools/Headless/ProgramHeadless.cs
@@ -123,7 +123,8 @@ namespace ModdingTools.Headless
             {
                 if(o.KillEditor)
                 {
-                    Utils.KillEditor();
+                    Logger.Log(LogLevel.Info, $"Killing editor...");
+                    Utils.KillEditor(false); // no need for async here, we can hold up the line because we're just exiting right after anyways
                     return 0;
                 }
 

--- a/ModdingTools/Properties/Resources.Designer.cs
+++ b/ModdingTools/Properties/Resources.Designer.cs
@@ -548,26 +548,23 @@ namespace ModdingTools.Properties {
         ///   Looks up a localized string similar to {
         /// &quot;version&quot;: &quot;2.0.0&quot;,
         /// &quot;tasks&quot;: [
-        ///  {
-        ///   &quot;label&quot;: &quot;Compile Mod&quot;,
-        ///   &quot;type&quot;: &quot;shell&quot;,
-        ///   &quot;command&quot;: &quot;##OMM:OMM_EXE_PATH##&quot;,
-        ///   &quot;args&quot;: [
-        ///    &quot;--mod&quot;,
-        ///    &quot;${workspaceFolderBasename}&quot;,
-        ///    &quot;--compilemod&quot;,
-        ///    &quot;--nologo&quot;
-        ///   ],
-        ///   &quot;problemMatcher&quot;: {
-        ///    &quot;owner&quot;: &quot;uc&quot;,
-        ///    &quot;fileLocation&quot;: [
-        ///     &quot;relative&quot;,
-        ///     &quot;${workspaceFolder}\\..\\&quot;
-        ///    ],
-        ///    &quot;source&quot;: &quot;Unrealscript Compilation&quot;,
-        ///    &quot;pattern&quot;: [
-        ///     {
-        ///      &quot;regexp&quot;: &quot;(?&lt;=(Error|Warn)\\]\\s{2})(.*(?=\\.uc)\\.uc).(\\d*).(?:\\s|:)* [rest of string was truncated]&quot;;.
+        ///    {
+        ///        &quot;label&quot;: &quot;Compile Mod&quot;,
+        ///        &quot;type&quot;: &quot;shell&quot;,
+        ///        &quot;command&quot;: &quot;##OMM:OMM_EXE_PATH##&quot;,
+        ///        &quot;args&quot;: [
+        ///            &quot;--mod&quot;,
+        ///            &quot;${workspaceFolderBasename}&quot;,
+        ///            &quot;--compilemod&quot;,
+        ///            &quot;--nologo&quot;
+        ///        ],
+        ///        &quot;problemMatcher&quot;: {
+        ///            &quot;owner&quot;: &quot;uc&quot;,
+        ///            &quot;fileLocation&quot;: [
+        ///                &quot;relative&quot;,
+        ///                &quot;${workspaceFolder}\\..\\&quot;
+        ///            ],
+        ///            &quot;source&quot;: &quot;Unrealscript Co [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string VSCodeTaskTemplate {
             get {

--- a/ModdingTools/Properties/Resources.Designer.cs
+++ b/ModdingTools/Properties/Resources.Designer.cs
@@ -546,35 +546,28 @@ namespace ModdingTools.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to {
-        ///	&quot;version&quot;: &quot;2.0.0&quot;,
-        ///	&quot;tasks&quot;: [
-        ///		{
-        ///			&quot;label&quot;: &quot;OMM: Compile&quot;,
-        ///			&quot;type&quot;: &quot;shell&quot;,
-        ///			&quot;command&quot;: &quot;##OMM:OMM_EXE_PATH##&quot;,
-        ///			&quot;args&quot;: [
-        ///				&quot;c&quot;,
-        ///				&quot;${file}&quot;
-        ///			],
-        ///			&quot;problemMatcher&quot;: [],
-        ///			&quot;group&quot;: {
-        ///				&quot;kind&quot;: &quot;build&quot;,
-        ///				&quot;isDefault&quot;: true
-        ///			}
-        ///		},
-        ///		{
-        ///			&quot;label&quot;: &quot;OMM: Compile and Cook&quot;,
-        ///			&quot;type&quot;: &quot;shell&quot;,
-        ///			&quot;command&quot;: &quot;##OMM:OMM_EXE_PATH##&quot;,
-        ///			&quot;args&quot;: [
-        ///				&quot;cc&quot;,
-        ///				&quot;${file}&quot;
-        ///			],
-        ///			&quot;problemMatcher&quot;: [],
-        ///			&quot;group&quot;: &quot;build&quot;
-        ///		},
-        ///        {
-        ///			&quot;label&quot;: &quot;OMM: Comp [rest of string was truncated]&quot;;.
+        /// &quot;version&quot;: &quot;2.0.0&quot;,
+        /// &quot;tasks&quot;: [
+        ///  {
+        ///   &quot;label&quot;: &quot;Compile Mod&quot;,
+        ///   &quot;type&quot;: &quot;shell&quot;,
+        ///   &quot;command&quot;: &quot;##OMM:OMM_EXE_PATH##&quot;,
+        ///   &quot;args&quot;: [
+        ///    &quot;--mod&quot;,
+        ///    &quot;${workspaceFolderBasename}&quot;,
+        ///    &quot;--compilemod&quot;,
+        ///    &quot;--nologo&quot;
+        ///   ],
+        ///   &quot;problemMatcher&quot;: {
+        ///    &quot;owner&quot;: &quot;uc&quot;,
+        ///    &quot;fileLocation&quot;: [
+        ///     &quot;relative&quot;,
+        ///     &quot;${workspaceFolder}\\..\\&quot;
+        ///    ],
+        ///    &quot;source&quot;: &quot;Unrealscript Compilation&quot;,
+        ///    &quot;pattern&quot;: [
+        ///     {
+        ///      &quot;regexp&quot;: &quot;(?&lt;=(Error|Warn)\\]\\s{2})(.*(?=\\.uc)\\.uc).(\\d*).(?:\\s|:)* [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string VSCodeTaskTemplate {
             get {
@@ -591,7 +584,7 @@ namespace ModdingTools.Properties {
         ///        &quot;path&quot;: &quot;./&quot;
         ///      },
         ///      {
-        ///        // Docs and release notes
+        ///        // A Hat In Time Source
         ///        &quot;name&quot;: &quot;AHiT Source&quot;,
         ///        &quot;path&quot;: &quot;##AHIT:SRC_ROOT##&quot;
         ///      }

--- a/ModdingTools/Properties/Resources.resx
+++ b/ModdingTools/Properties/Resources.resx
@@ -273,145 +273,146 @@
     <value>{
  "version": "2.0.0",
  "tasks": [
-  {
-   "label": "Compile Mod",
-   "type": "shell",
-   "command": "##OMM:OMM_EXE_PATH##",
-   "args": [
-    "--mod",
-    "${workspaceFolderBasename}",
-    "--compilemod",
-    "--nologo"
-   ],
-   "problemMatcher": {
-    "owner": "uc",
-    "fileLocation": [
-     "relative",
-     "${workspaceFolder}\\..\\"
-    ],
-    "source": "Unrealscript Compilation",
-    "pattern": [
-     {
-      "regexp": "(?&lt;=(Error|Warn)\\]\\s{2})(.*(?=\\.uc)\\.uc).(\\d*).(?:\\s|:)*(.*)",
-      "severity": 1,
-      "file": 2,
-      "line": 3,
-      "message": 4
-     }
-    ]
-   },
-   "group": "build"
-  },
-  {
-   "label": "Cook Mod",
-   "type": "shell",
-   "command": "##OMM:OMM_EXE_PATH##",
-   "args": [
-    "--mod",
-    "${workspaceFolderBasename}",
-    "--cookmod",
-    "--nologo"
-   ],
-   "group": "build"
-  },
-  {
-   "label": "Compile and Cook",
-   "dependsOrder": "sequence",
-   "dependsOn": [
-    "Compile Mod",
-    "Cook Mod"
-   ],
-   "group": "build",
-  },
-  {
-   "label": "Launch Editor",
-   "type": "shell",
-   "command": "##OMM:OMM_EXE_PATH##",
-   "args": [
-    "--editor",
-    "--nologo"
-   ],
-   "problemMatcher": [],
-   "group": "test"
-  },
-  {
-   "label": "Launch Game (No Workshop Mods)",
-   "type": "shell",
-   "command": "##OMM:OMM_EXE_PATH##",
-   "args": [
-    "--mod",
-    "${workspaceFolderBasename}",
-    "--testmap",
-    "${input:TestMap}",
-    "--nologo"
-   ],
-   "group": "test"
-  },
-  {
-   "label": "Launch Game (With Workshop Mods)",
-   "type": "shell",
-   "command": "##OMM:OMM_EXE_PATH##",
-   "args": [
-    "--mod",
-    "${workspaceFolderBasename}",
-    "--testmapall",
-    "${input:TestMap}",
-    "--nologo"
-   ],
-   "group": "test"
-  },
-  {
-   "label": "Compile &amp; Launch Editor",
-   "dependsOrder": "sequence",
-   "dependsOn": [
-    "Compile Mod",
-    "Launch Editor"
-   ],
-   "group": {
-    "kind": "build",
-    "isDefault": true
-   }
-  },
-  {
-   "label": "Compile, Cook &amp; Launch Game (No Workshop Mods)",
-   "dependsOrder": "sequence",
-   "dependsOn": [
-    "Compile and Cook",
-    "Launch Game (No Workshop Mods)"
-   ],
-   "group": {
-    "kind": "test",
-    "isDefault": true
-   },
-   "detail": "You will be asked to input a map name when the game is launched."
-  },
-  {
-   "label": "Compile, Cook &amp; Launch Game (With Workshop Mods)",
-   "dependsOrder": "sequence",
-   "dependsOn": [
-    "Compile and Cook",
-    "Launch Game (With Workshop Mods)"
-   ],
-   "group": "test",
-   "detail": "You will be asked to input a map name when the game is launched."
-  },
-  {
-   "label": "Kill Editor",
-   "type": "shell",
-   "command": "##OMM:OMM_EXE_PATH##",
-   "args": [
-    "--killeditor"
-   ],
-
-   "group": "none", // Utility, but VSCode doesn't have a group for that
-   "detail": "Instantly ends the editor process. Be careful of unsaved progress!",
-   "presentation": {
-    "echo": true,
-    "reveal": "never",
-    "focus": false
-   }
-  }
- ],
+    {
+        "label": "Compile Mod",
+        "type": "shell",
+        "command": "##OMM:OMM_EXE_PATH##",
+        "args": [
+            "--mod",
+            "${workspaceFolderBasename}",
+            "--compilemod",
+            "--nologo"
+        ],
+        "problemMatcher": {
+            "owner": "uc",
+            "fileLocation": [
+                "relative",
+                "${workspaceFolder}\\..\\"
+            ],
+            "source": "Unrealscript Compilation",
+            "pattern": [
+                {
+                    "regexp": "(?&lt;=(Error|Warn)\\]\\s{2})(.*(?=\\.uc)\\.uc).(\\d*).(?:\\s|:)*(.*)",
+                    "severity": 1,
+                    "file": 2,
+                    "line": 3,
+                    "message": 4
+                }
+            ]
+        },
+        "group": "build"
+    },
+    {
+        "label": "Cook Mod",
+        "type": "shell",
+        "command": "##OMM:OMM_EXE_PATH##",
+        "args": [
+            "--mod",
+            "${workspaceFolderBasename}",
+            "--cookmod",
+            "--nologo"
+        ],
+        "group": "build"
+    },
+    {
+        "label": "Compile and Cook",
+        "dependsOrder": "sequence",
+        "dependsOn": [
+            "Compile Mod",
+            "Cook Mod"
+        ],
+        "group": "build"
+    },
+    {
+        "label": "Launch Editor",
+        "type": "shell",
+        "command": "##OMM:OMM_EXE_PATH##",
+        "args": [
+            "--editor",
+            "--nologo"
+        ],
+        "problemMatcher": [],
+        "group": "test"
+    },
+    {
+        "label": "Launch Game (No Workshop Mods)",
+        "type": "shell",
+        "command": "##OMM:OMM_EXE_PATH##",
+        "args": [
+            "--mod",
+            "${workspaceFolderBasename}",
+            "--testmap",
+            "${input:TestMap}",
+            "--nologo"
+        ],
+        "group": "test"
+    },
+    {
+        "label": "Launch Game (With Workshop Mods)",
+        "type": "shell",
+        "command": "##OMM:OMM_EXE_PATH##",
+        "args": [
+            "--mod",
+            "${workspaceFolderBasename}",
+            "--testmapall",
+            "${input:TestMap}",
+            "--nologo"
+        ],
+        "group": "test"
+    },
+    {
+        "label": "Compile &amp; Launch Editor",
+        "dependsOrder": "sequence",
+        "dependsOn": [
+            "Compile Mod",
+            "Launch Editor"
+        ],
+        "group": {
+            "kind": "build",
+            "isDefault": true
+        }
+    },
+    {
+        "label": "Compile, Cook &amp; Launch Game (No Workshop Mods)",
+        "dependsOrder": "sequence",
+        "dependsOn": [
+            "Compile and Cook",
+            "Launch Game (No Workshop Mods)"
+        ],
+        "group": {
+            "kind": "test",
+            "isDefault": true
+        },
+        "detail": "You will be asked to input a map name when the game is launched."
+    },
+    {
+        "label": "Compile, Cook &amp; Launch Game (With Workshop Mods)",
+        "dependsOrder": "sequence",
+        "dependsOn": [
+            "Compile and Cook",
+            "Launch Game (With Workshop Mods)"
+        ],
+        "group": "test",
+        "detail": "You will be asked to input a map name when the game is launched."
+    },
+    {
+        "label": "Kill Editor",
+        "type": "shell",
+        "command": "##OMM:OMM_EXE_PATH##",
+        "args": [
+            "--killeditor",
+            "--nologo"
+        ],
+        "group": "none",
+        "detail": "Instantly ends the editor process. Be careful of unsaved progress!",
+        "presentation": {
+            "echo": true,
+            "reveal": "never",
+            "focus": false
+        },
+        "problemMatcher": []
+    }
+],
  "inputs": [
   // Map input for launching the game. Defaults to titlescreen
   {

--- a/ModdingTools/Properties/Resources.resx
+++ b/ModdingTools/Properties/Resources.resx
@@ -394,6 +394,22 @@
    ],
    "group": "test",
    "detail": "You will be asked to input a map name when the game is launched."
+  },
+  {
+   "label": "Kill Editor",
+   "type": "shell",
+   "command": "##OMM:OMM_EXE_PATH##",
+   "args": [
+    "--killeditor"
+   ],
+
+   "group": "none", // Utility, but VSCode doesn't have a group for that
+   "detail": "Instantly ends the editor process. Be careful of unsaved progress!",
+   "presentation": {
+    "echo": true,
+    "reveal": "never",
+    "focus": false
+   }
   }
  ],
  "inputs": [

--- a/ModdingTools/Properties/Resources.resx
+++ b/ModdingTools/Properties/Resources.resx
@@ -300,6 +300,16 @@
                 }
             ]
         },
+        "presentation": {
+            "echo": true,
+            "reveal": "always",
+            "focus": false,
+            "panel": "shared",
+            "showReuseMessage": true,
+            "revealProblems": "onProblem",
+            "clear": true,
+            "group": "Building"
+        },
         "group": "build"
     },
     {
@@ -312,7 +322,16 @@
             "--cookmod",
             "--nologo"
         ],
-        "group": "build"
+        "group": "build",
+        "presentation": {
+            "echo": true,
+            "reveal": "always",
+            "focus": false,
+            "panel": "shared",
+            "showReuseMessage": false,
+            "clear": true,
+            "group": "Building"
+        }
     },
     {
         "label": "Compile and Cook",
@@ -332,7 +351,17 @@
             "--nologo"
         ],
         "problemMatcher": [],
-        "group": "test"
+        "group": "test",
+
+        "presentation": {
+            "echo": true,
+            "reveal": "never",
+            "focus": false,
+            "panel": "shared",
+            "showReuseMessage": true,
+            "clear": false,
+            "group": "Testing"
+        }
     },
     {
         "label": "Launch Game (No Workshop Mods)",
@@ -345,7 +374,17 @@
             "${input:TestMap}",
             "--nologo"
         ],
-        "group": "test"
+        "group": "test",
+
+        "presentation": {
+            "echo": true,
+            "reveal": "never",
+            "focus": false,
+            "panel": "shared",
+            "showReuseMessage": true,
+            "clear": false,
+            "group": "Testing"
+        }
     },
     {
         "label": "Launch Game (With Workshop Mods)",
@@ -358,7 +397,17 @@
             "${input:TestMap}",
             "--nologo"
         ],
-        "group": "test"
+        "group": "test",
+
+        "presentation": {
+            "echo": true,
+            "reveal": "never",
+            "focus": false,
+            "panel": "shared",
+            "showReuseMessage": true,
+            "clear": false,
+            "group": "Testing"
+        }
     },
     {
         "label": "Compile &amp; Launch Editor",

--- a/ModdingTools/Properties/Resources.resx
+++ b/ModdingTools/Properties/Resources.resx
@@ -271,89 +271,140 @@
   </data>
   <data name="VSCodeTaskTemplate" xml:space="preserve">
     <value>{
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"label": "OMM: Compile",
-			"type": "shell",
-			"command": "##OMM:OMM_EXE_PATH##",
-			"args": [
-				"c",
-				"${file}"
-			],
-			"problemMatcher": [],
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		},
-		{
-			"label": "OMM: Compile and Cook",
-			"type": "shell",
-			"command": "##OMM:OMM_EXE_PATH##",
-			"args": [
-				"cc",
-				"${file}"
-			],
-			"problemMatcher": [],
-			"group": "build"
-		},
-        {
-			"label": "OMM: Compile and launch editor",
-			"type": "shell",
-			"command": "##OMM:OMM_EXE_PATH##",
-			"args": [
-				"ce",
-				"${file}"
-			],
-			"problemMatcher": [],
-			"group": "build"
-		},
-        {
-			"label": "OMM: Compile and Cook and launch game (only mods folder, last visited map)",
-			"type": "shell",
-			"command": "##OMM:OMM_EXE_PATH##",
-			"args": [
-				"cg",
-				"${file}"
-			],
-			"problemMatcher": [],
-			"group": "build"
-		},
-        {
-			"label": "OMM: Compile and Cook and launch game (only mods folder, choose map)",
-			"type": "shell",
-			"command": "##OMM:OMM_EXE_PATH##",
-			"args": [
-				"cm",
-				"${file}"
-			],
-			"problemMatcher": [],
-			"group": "build"
-		},
-        {
-			"label": "OMM: Compile and Cook and launch game (with workshop mods, last visited map)",
-			"type": "shell",
-			"command": "##OMM:OMM_EXE_PATH##",
-			"args": [
-				"ci",
-				"${file}"
-			],
-			"problemMatcher": [],
-			"group": "build"
-		},
-        {
-			"label": "OMM: Compile and Cook and launch game (with workshop mods, choose map)",
-			"type": "shell",
-			"command": "##OMM:OMM_EXE_PATH##",
-			"args": [
-				"cn",
-				"${file}"
-			],
-			"problemMatcher": [],
-			"group": "build"
-		}
-	]
+ "version": "2.0.0",
+ "tasks": [
+  {
+   "label": "Compile Mod",
+   "type": "shell",
+   "command": "##OMM:OMM_EXE_PATH##",
+   "args": [
+    "--mod",
+    "${workspaceFolderBasename}",
+    "--compilemod",
+    "--nologo"
+   ],
+   "problemMatcher": {
+    "owner": "uc",
+    "fileLocation": [
+     "relative",
+     "${workspaceFolder}\\..\\"
+    ],
+    "source": "Unrealscript Compilation",
+    "pattern": [
+     {
+      "regexp": "(?&lt;=(Error|Warn)\\]\\s{2})(.*(?=\\.uc)\\.uc).(\\d*).(?:\\s|:)*(.*)",
+      "severity": 1,
+      "file": 2,
+      "line": 3,
+      "message": 4
+     }
+    ]
+   },
+   "group": "build"
+  },
+  {
+   "label": "Cook Mod",
+   "type": "shell",
+   "command": "##OMM:OMM_EXE_PATH##",
+   "args": [
+    "--mod",
+    "${workspaceFolderBasename}",
+    "--cookmod",
+    "--nologo"
+   ],
+   "group": "build"
+  },
+  {
+   "label": "Compile and Cook",
+   "dependsOrder": "sequence",
+   "dependsOn": [
+    "Compile Mod",
+    "Cook Mod"
+   ],
+   "group": "build",
+  },
+  {
+   "label": "Launch Editor",
+   "type": "shell",
+   "command": "##OMM:OMM_EXE_PATH##",
+   "args": [
+    "--editor",
+    "--nologo"
+   ],
+   "problemMatcher": [],
+   "group": "test"
+  },
+  {
+   "label": "Launch Game (No Workshop Mods)",
+   "type": "shell",
+   "command": "##OMM:OMM_EXE_PATH##",
+   "args": [
+    "--mod",
+    "${workspaceFolderBasename}",
+    "--testmap",
+    "${input:TestMap}",
+    "--nologo"
+   ],
+   "group": "test"
+  },
+  {
+   "label": "Launch Game (With Workshop Mods)",
+   "type": "shell",
+   "command": "##OMM:OMM_EXE_PATH##",
+   "args": [
+    "--mod",
+    "${workspaceFolderBasename}",
+    "--testmapall",
+    "${input:TestMap}",
+    "--nologo"
+   ],
+   "group": "test"
+  },
+  {
+   "label": "Compile &amp; Launch Editor",
+   "dependsOrder": "sequence",
+   "dependsOn": [
+    "Compile Mod",
+    "Launch Editor"
+   ],
+   "group": {
+    "kind": "build",
+    "isDefault": true
+   }
+  },
+  {
+   "label": "Compile, Cook &amp; Launch Game (No Workshop Mods)",
+   "dependsOrder": "sequence",
+   "dependsOn": [
+    "Compile and Cook",
+    "Launch Game (No Workshop Mods)"
+   ],
+   "group": {
+    "kind": "test",
+    "isDefault": true
+   },
+   "detail": "You will be asked to input a map name when the game is launched."
+  },
+  {
+   "label": "Compile, Cook &amp; Launch Game (With Workshop Mods)",
+   "dependsOrder": "sequence",
+   "dependsOn": [
+    "Compile and Cook",
+    "Launch Game (With Workshop Mods)"
+   ],
+   "group": "test",
+   "detail": "You will be asked to input a map name when the game is launched."
+  }
+ ],
+ "inputs": [
+  // Map input for launching the game. Defaults to titlescreen
+  {
+   "id": "TestMap",
+   "description": "Map:",
+   "type": "promptString",
+   "default": "titlescreen_final",
+  }
+ ]
 }</value>
   </data>
   <data name="VSCodeWorkspaceTemplate" xml:space="preserve">
@@ -365,7 +416,7 @@
         "path": "./"
       },
       {
-        // Docs and release notes
+        // A Hat In Time Source
         "name": "AHiT Source",
         "path": "##AHIT:SRC_ROOT##"
       }


### PR DESCRIPTION
These tasks were present before, but they triggered an error.
<img width="1041" height="63" alt="image" src="https://github.com/user-attachments/assets/787780e1-c510-4622-932c-ac71fcb44d1c" />
This pull request fixes the error and generally makes the task experience cleaner.

Also adds a new `Kill Editor` task and a `ProblemMatcher` for the UnrealScript compiler.
<img width="713" height="387" alt="image" src="https://github.com/user-attachments/assets/106872d4-148b-480c-bd44-64373639cea3" />